### PR TITLE
Add sign-up profile insert policy

### DIFF
--- a/docs/supabase-setup.sql
+++ b/docs/supabase-setup.sql
@@ -89,6 +89,11 @@ CREATE POLICY "Les utilisateurs peuvent mettre à jour leur propre profil" ON pr
 FOR UPDATE
 USING (auth.uid() = id);
 
+CREATE POLICY "Les utilisateurs peuvent créer leur profil" ON profiles
+FOR INSERT
+TO anon
+WITH CHECK (auth.uid() = id);
+
 CREATE POLICY "Les administrateurs peuvent tout voir" ON profiles
 FOR ALL
 USING (EXISTS (


### PR DESCRIPTION
## Summary
- allow anonymous users to insert into `profiles` so sign-up can create a profile

## Testing
- `npm test`
