### PR TITLE
Fix document column names

### DIFF
--- a/src/pages/client/Dashboard.jsx
+++ b/src/pages/client/Dashboard.jsx
@@ -230,13 +230,13 @@ const Dashboard = () => {
                 {documents.slice(0, 5).map((document) => (
                   <tr key={document.id}>
                     <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900">
-                      {document.name}
+                      {document.file_name}
                     </td>
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      {document.type}
+                      {document.category}
                     </td>
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      {new Date(document.created_at).toLocaleDateString('fr-FR')}
+                      {new Date(document.uploaded_at).toLocaleDateString('fr-FR')}
                     </td>
                     <td className="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                       <a 

--- a/src/pages/client/Documents.jsx
+++ b/src/pages/client/Documents.jsx
@@ -31,7 +31,7 @@ const Documents = () => {
           .from('documents')
           .select('*')
           .eq('user_id', user.id)
-          .order('created_at', { ascending: false });
+          .order('uploaded_at', { ascending: false });
         if (error) throw error;
         setDocuments(data || []);
       } catch (error) {
@@ -92,11 +92,13 @@ const Documents = () => {
         .insert([
           {
             user_id: user.id,
-            name: documentName,
-            type: documentType,
+            file_name: documentName,
+            file_type: file.type,
+            file_size: file.size,
             file_url: fileUrl,
-            storage_path: filePath,
-            created_at: new Date()
+            file_path: filePath,
+            category: documentType,
+            uploaded_at: new Date()
           }
         ]);
       if (insertError) throw insertError;
@@ -110,7 +112,7 @@ const Documents = () => {
         .from('documents')
         .select('*')
         .eq('user_id', user.id)
-        .order('created_at', { ascending: false });
+        .order('uploaded_at', { ascending: false });
       if (error) throw error;
       setDocuments(updatedDocs || []);
     } catch (error) {
@@ -262,13 +264,13 @@ const Documents = () => {
                 {documents.map((document) => (
                   <tr key={document.id}>
                     <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900">
-                      {document.name}
+                      {document.file_name}
                     </td>
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      {documentTypes.find(t => t.id === document.type)?.name || document.type}
+                      {documentTypes.find(t => t.id === document.category)?.name || document.category}
                     </td>
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      {new Date(document.created_at).toLocaleDateString('fr-FR')}
+                      {new Date(document.uploaded_at).toLocaleDateString('fr-FR')}
                     </td>
                     <td className="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                       <div className="flex justify-end space-x-3">
@@ -281,7 +283,7 @@ const Documents = () => {
                           Voir
                         </a>
                         <button
-                          onClick={() => handleDelete(document.id, document.storage_path)}
+                          onClick={() => handleDelete(document.id, document.file_path)}
                           className="text-red-600 hover:text-red-900"
                           type="button"
                         >

--- a/src/pages/client/LoanDetails.jsx
+++ b/src/pages/client/LoanDetails.jsx
@@ -274,13 +274,13 @@ const LoanDetails = () => {
                 {documents.map((document) => (
                   <tr key={document.id}>
                     <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900">
-                      {document.name}
+                      {document.file_name}
                     </td>
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      {document.type}
+                      {document.category}
                     </td>
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      {new Date(document.created_at).toLocaleDateString('fr-FR')}
+                      {new Date(document.uploaded_at).toLocaleDateString('fr-FR')}
                     </td>
                     <td className="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                       <a 

--- a/src/pages/client/NewLoanRequest.jsx
+++ b/src/pages/client/NewLoanRequest.jsx
@@ -60,13 +60,31 @@ const NewLoanRequest = () => {
       // Mettre à jour l'état correspondant
       switch (type) {
         case 'id':
-          setIdDocument({ name: file.name, url: fileUrl, path: filePath });
+          setIdDocument({
+            file_name: file.name,
+            file_type: file.type,
+            file_size: file.size,
+            file_url: fileUrl,
+            file_path: filePath,
+          });
           break;
         case 'income':
-          setProofOfIncome({ name: file.name, url: fileUrl, path: filePath });
+          setProofOfIncome({
+            file_name: file.name,
+            file_type: file.type,
+            file_size: file.size,
+            file_url: fileUrl,
+            file_path: filePath,
+          });
           break;
         case 'bank':
-          setBankStatements({ name: file.name, url: fileUrl, path: filePath });
+          setBankStatements({
+            file_name: file.name,
+            file_type: file.type,
+            file_size: file.size,
+            file_url: fileUrl,
+            file_path: filePath,
+          });
           break;
         default:
           break;
@@ -149,9 +167,9 @@ const NewLoanRequest = () => {
             duration_months: parseInt(duration),
             purpose,
             status: 'pending',
-            id_document_url: idDocument?.url,
-            income_proof_url: proofOfIncome?.url,
-            bank_statements_url: bankStatements?.url,
+            id_document_url: idDocument?.file_url,
+            income_proof_url: proofOfIncome?.file_url,
+            bank_statements_url: bankStatements?.file_url,
             created_at: new Date()
           }
         ])
@@ -164,29 +182,35 @@ const NewLoanRequest = () => {
         {
           user_id: user.id,
           loan_id: data[0].id,
-          name: idDocument.name,
-          type: 'Pièce d\'identité',
-          file_url: idDocument.url,
-          storage_path: idDocument.path,
-          created_at: new Date()
+          file_name: idDocument.file_name,
+          file_type: idDocument.file_type,
+          file_size: idDocument.file_size,
+          file_url: idDocument.file_url,
+          file_path: idDocument.file_path,
+          category: 'identite',
+          uploaded_at: new Date()
         },
         {
           user_id: user.id,
           loan_id: data[0].id,
-          name: proofOfIncome.name,
-          type: 'Justificatif de revenu',
-          file_url: proofOfIncome.url,
-          storage_path: proofOfIncome.path,
-          created_at: new Date()
+          file_name: proofOfIncome.file_name,
+          file_type: proofOfIncome.file_type,
+          file_size: proofOfIncome.file_size,
+          file_url: proofOfIncome.file_url,
+          file_path: proofOfIncome.file_path,
+          category: 'revenu',
+          uploaded_at: new Date()
         },
         {
           user_id: user.id,
           loan_id: data[0].id,
-          name: bankStatements.name,
-          type: 'Relevés bancaires',
-          file_url: bankStatements.url,
-          storage_path: bankStatements.path,
-          created_at: new Date()
+          file_name: bankStatements.file_name,
+          file_type: bankStatements.file_type,
+          file_size: bankStatements.file_size,
+          file_url: bankStatements.file_url,
+          file_path: bankStatements.file_path,
+          category: 'revenu',
+          uploaded_at: new Date()
         }
       ];
       
@@ -356,7 +380,7 @@ const NewLoanRequest = () => {
                           <svg className="flex-shrink-0 mr-1.5 h-5 w-5 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                             <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                           </svg>
-                          <span>{idDocument.name}</span>
+                          <span>{idDocument.file_name}</span>
                         </div>
                       ) : (
                         <div className="max-w-lg flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
@@ -397,7 +421,7 @@ const NewLoanRequest = () => {
                           <svg className="flex-shrink-0 mr-1.5 h-5 w-5 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                             <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                           </svg>
-                          <span>{proofOfIncome.name}</span>
+                          <span>{proofOfIncome.file_name}</span>
                         </div>
                       ) : (
                         <div className="max-w-lg flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
@@ -438,7 +462,7 @@ const NewLoanRequest = () => {
                           <svg className="flex-shrink-0 mr-1.5 h-5 w-5 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                             <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                           </svg>
-                          <span>{bankStatements.name}</span>
+                          <span>{bankStatements.file_name}</span>
                         </div>
                       ) : (
                         <div className="max-w-lg flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">

--- a/src/services/documentService.js
+++ b/src/services/documentService.js
@@ -22,7 +22,7 @@ export const uploadDocument = async (file, userId, loanRequestId) => {
     const { error: dbError } = await supabase
       .from('documents')
       .insert({
-        loan_request_id: loanRequestId,
+        loan_id: loanRequestId,
         user_id: userId,
         file_path: filePath,
         file_name: file.name,
@@ -47,7 +47,7 @@ export const getUserDocuments = async (userId, loanRequestId = null) => {
       .eq('user_id', userId);
     
     if (loanRequestId) {
-      query = query.eq('loan_request_id', loanRequestId);
+      query = query.eq('loan_id', loanRequestId);
     }
     
     const { data, error } = await query;


### PR DESCRIPTION
## Summary
- use `file_name`, `file_type`, `file_path`, `file_size`, `category` and `uploaded_at` when creating documents
- update document queries and displays to match new column names
- align document service with `loan_id`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*