### PR TITLE
Fix bank statement category

### DIFF
--- a/docs/supabase-setup.sql
+++ b/docs/supabase-setup.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS documents (
   file_url TEXT NOT NULL,
   file_type TEXT NOT NULL,
   file_size BIGINT NOT NULL,
-  category TEXT NOT NULL CHECK (category IN ('identite', 'revenu', 'domicile', 'professionnel', 'autre')),
+  category TEXT NOT NULL CHECK (category IN ('identite', 'revenu', 'banque', 'domicile', 'professionnel', 'autre')),
   uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/src/pages/admin/ClientDetails.jsx
+++ b/src/pages/admin/ClientDetails.jsx
@@ -213,6 +213,7 @@ const ClientDetails = () => {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           {doc.category === 'identite' && 'Pièce d\'identité'}
                           {doc.category === 'revenu' && 'Justificatif de revenu'}
+                          {doc.category === 'banque' && 'Relevés bancaires'}
                           {doc.category === 'domicile' && 'Justificatif de domicile'}
                           {doc.category === 'professionnel' && 'Document professionnel'}
                           {doc.category === 'autre' && 'Autre document'}

--- a/src/pages/admin/LoanDetails.jsx
+++ b/src/pages/admin/LoanDetails.jsx
@@ -341,6 +341,7 @@ const LoanDetails = () => {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           {doc.category === 'identite' && 'Pièce d\'identité'}
                           {doc.category === 'revenu' && 'Justificatif de revenu'}
+                          {doc.category === 'banque' && 'Relevés bancaires'}
                           {doc.category === 'domicile' && 'Justificatif de domicile'}
                           {doc.category === 'professionnel' && 'Document professionnel'}
                           {doc.category === 'autre' && 'Autre document'}

--- a/src/pages/client/NewLoanRequest.jsx
+++ b/src/pages/client/NewLoanRequest.jsx
@@ -209,7 +209,7 @@ const NewLoanRequest = () => {
           file_size: bankStatements.file_size,
           file_url: bankStatements.file_url,
           file_path: bankStatements.file_path,
-          category: 'revenu',
+          category: 'banque',
           uploaded_at: new Date()
         }
       ];


### PR DESCRIPTION
## Summary
- add `banque` category in database setup
- categorize bank statements as `banque`
- render `banque` documents in admin pages

## Testing
- `npm test` *(fails: Cannot find module 'signal-exit')*