### PR TITLE
Switch Supabase bucket

### DIFF
--- a/src/pages/client/Documents.jsx
+++ b/src/pages/client/Documents.jsx
@@ -78,12 +78,12 @@ const Documents = () => {
       const filePath = `documents/${fileName}`;
       // Télécharger le fichier
       const { error: uploadError } = await supabase.storage
-        .from('documents')
+        .from('uploads')
         .upload(filePath, file);
       if (uploadError) throw uploadError;
       // Obtenir l'URL du fichier
       const { data } = await supabase.storage
-        .from('documents')
+        .from('uploads')
         .getPublicUrl(filePath);
       const fileUrl = data.publicUrl;
       // Enregistrer le document dans la base de données
@@ -130,7 +130,7 @@ const Documents = () => {
     try {
       // Supprimer le fichier du stockage
       if (storagePath) {
-        await supabase.storage.from('documents').remove([storagePath]);
+        await supabase.storage.from('uploads').remove([storagePath]);
       }
       // Supprimer l'entrée de la base de données
       const { error } = await supabase

--- a/src/pages/client/NewLoanRequest.jsx
+++ b/src/pages/client/NewLoanRequest.jsx
@@ -45,14 +45,14 @@ const NewLoanRequest = () => {
       
       // Télécharger le fichier dans le bucket "documents"
       const { error: uploadError } = await supabase.storage
-        .from('documents')
+        .from('uploads')
         .upload(filePath, file);
       
       if (uploadError) throw uploadError;
       
       // Obtenir l'URL du fichier
       const { data } = await supabase.storage
-        .from('documents')
+        .from('uploads')
         .getPublicUrl(filePath);
       
       const fileUrl = data.publicUrl;

--- a/src/services/documentService.js
+++ b/src/services/documentService.js
@@ -8,14 +8,14 @@ export const uploadDocument = async (file, userId, loanRequestId) => {
     
     // Upload du fichier
     const { error: uploadError } = await supabase.storage
-      .from('documents')
+      .from('uploads')
       .upload(filePath, file);
       
     if (uploadError) throw uploadError;
     
     // Récupération de l'URL du fichier
     const { data: { publicUrl } } = supabase.storage
-      .from('documents')
+      .from('uploads')
       .getPublicUrl(filePath);
     
     // Enregistrement des métadonnées dans la base de données
@@ -63,7 +63,7 @@ export const getUserDocuments = async (userId, loanRequestId = null) => {
 export const getDocumentUrl = async (filePath) => {
   try {
     const { data: { publicUrl } } = supabase.storage
-      .from('documents')
+      .from('uploads')
       .getPublicUrl(filePath);
       
     return publicUrl;
@@ -86,7 +86,7 @@ export const deleteDocument = async (documentId) => {
     
     // Supprimer le fichier du stockage
     const { error: storageError } = await supabase.storage
-      .from('documents')
+      .from('uploads')
       .remove([document.file_path]);
     
     if (storageError) throw storageError;


### PR DESCRIPTION
## Summary
- use `uploads` bucket for Supabase storage

## Testing
- `npm test` *(fails: Cannot find module 'signal-exit')*
- `npm run lint` *(fails: 47 errors, 21 warnings)*