### PR TITLE
Update profile fields

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -32,11 +32,11 @@ export const signUp = async (email, password, userData) => {
         .update({
           first_name: userData.first_name || userData.firstName || '',
           last_name: userData.last_name || userData.lastName || '',
-          telephone: userData.telephone || '',
-          adresse: userData.adresse || '',
-          ville: userData.ville || '',
-          pays: userData.pays || '',
-          code_postal: userData.code_postal || ''
+          phone: userData.phone || '',
+          address: userData.address || '',
+          city: userData.city || '',
+          country: userData.country || '',
+          postal_code: userData.postal_code || ''
         })
         .eq('id', authData.user.id);
       

--- a/src/services/loanService.js
+++ b/src/services/loanService.js
@@ -40,7 +40,7 @@ export const getLoanRequestById = async (id, isAdmin = false) => {
       .from('loan_requests')
       .select(`
         *,
-        profiles:user_id (first_name, last_name, telephone, email)
+        profiles:user_id (first_name, last_name, phone, email)
       `)
       .eq('id', id)
       .single();
@@ -96,7 +96,7 @@ export const getAllLoanRequests = async () => {
       .from('loan_requests')
       .select(`
         *,
-        profiles:user_id (first_name, last_name, telephone)
+        profiles:user_id (first_name, last_name, phone)
       `)
       .order('created_at', { ascending: false });
     


### PR DESCRIPTION
## Summary
- update profile field selections to use `phone`
- migrate to new `phone`, `address`, `city`, `country`, `postal_code` fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a505556848322a8f903499aa4c6e3