### PR TITLE
Fix register API error handling

### DIFF
--- a/api/register.js
+++ b/api/register.js
@@ -1,18 +1,20 @@
 /* eslint-env node */
 import { createClient } from '@supabase/supabase-js'
 
-if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-  throw new Error(
-    'Missing SUPABASE_SERVICE_ROLE_KEY environment variable'
+// Initialise le client seulement si toutes les variables sont disponibles
+let supabaseAdmin = null
+if (process.env.VITE_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  supabaseAdmin = createClient(
+    process.env.VITE_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
   )
 }
 
-const supabaseAdmin = createClient(
-  process.env.VITE_SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
-
 export default async function handler(req, res) {
+  if (!supabaseAdmin) {
+    res.status(500).json({ error: 'Server misconfigured' })
+    return
+  }
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' })
     return

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -44,7 +44,12 @@ export const AuthProvider = ({ children }) => {
         body: JSON.stringify({ fullName, email, password })
       })
 
-      const data = await response.json()
+      let data
+      try {
+        data = await response.json()
+      } catch {
+        data = { error: 'Invalid server response' }
+      }
       if (!response.ok) throw new Error(data.error || 'Registration failed')
 
       // Connexion automatique après inscription


### PR DESCRIPTION
## Summary
- initialize supabase client defensively in API route
- return a JSON error if the server is misconfigured
- guard JSON parsing in `register` frontend helper

## Testing
- `npm test` *(fails: Cannot find module 'signal-exit')*

------
https://chatgpt.com/codex/tasks/task_e_683a53aecb4c8322925cf0ac0442e25c