### PR TITLE
Add check for missing service role key

### DIFF
--- a/api/register.js
+++ b/api/register.js
@@ -11,6 +11,9 @@ if (process.env.VITE_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
 }
 
 export default async function handler(req, res) {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return res.status(500).json({ error: 'SUPABASE_SERVICE_ROLE_KEY missing' })
+  }
   if (!supabaseAdmin) {
     res.status(500).json({ error: 'Server misconfigured' })
     return


### PR DESCRIPTION
## Summary
- warn if SUPABASE_SERVICE_ROLE_KEY env is missing before using supabase admin SDK

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a5921ea7483228dd32cbebf259347