### PR TITLE
Improve registration error handling

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -44,11 +44,16 @@ export const AuthProvider = ({ children }) => {
         body: JSON.stringify({ fullName, email, password })
       })
 
+      const contentType = response.headers.get('content-type')
+      if (!contentType || !contentType.includes('application/json')) {
+        return { data: null, error: new Error('Erreur technique : réponse du serveur invalide') }
+      }
+
       let data
       try {
         data = await response.json()
       } catch {
-        data = { error: 'Invalid server response' }
+        return { data: null, error: new Error('Erreur technique : réponse du serveur invalide') }
       }
       if (!response.ok) throw new Error(data.error || 'Registration failed')
 


### PR DESCRIPTION
## Summary
- check `content-type` header before parsing registration response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a5923298083229e765a12c7a4cf23