### PR TITLE
Remove signal-exit override

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Application web complète pour Africa Invest Capital, une société financière 
 git clone https://github.com/votre-username/africa-invest-capital.git
 cd africa-invest-capital
 npm install
+# ⚠️ Ne pas ajouter manuellement la dépendance `signal-exit` dans `package.json`. Elle est installée automatiquement par les outils qui en ont besoin et son ajout explicite provoque des conflits de build, notamment sur Vercel.
 
 # Copier le fichier d'exemple et renseigner vos variables
 cp .env.example .env

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "vite-plugin-pwa": "^0.16.4",
     "workbox-window": "^7.0.0"
   },
-  "overrides": {
-    "signal-exit": "^4.1.0"
-  },
   "engines": {
     "node": ">=18.0.0"
   }


### PR DESCRIPTION
## Summary
- remove explicit signal-exit override from package.json
- note not to manually add signal-exit dependency in README

## Testing
- `npm run build` *(fails: esbuild installed for darwin-arm64)*

------
https://chatgpt.com/codex/tasks/task_e_683ade0747b083228ae980c14441ace4