### PR TITLE
Update server error text in register function

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -46,14 +46,14 @@ export const AuthProvider = ({ children }) => {
 
       const contentType = response.headers.get('content-type')
       if (!contentType || !contentType.includes('application/json')) {
-        return { data: null, error: new Error('Erreur technique : réponse du serveur invalide') }
+        return { data: null, error: new Error('Erreur serveur, contactez le support') }
       }
 
       let data
       try {
         data = await response.json()
       } catch {
-        return { data: null, error: new Error('Erreur technique : réponse du serveur invalide') }
+        return { data: null, error: new Error('Erreur serveur, contactez le support') }
       }
       if (!response.ok) throw new Error(data.error || 'Registration failed')
 


### PR DESCRIPTION
## Summary
- tweak error messages in `AuthContext` registration logic

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683ae5b2f878832299329c7f18c8d9c9