### PR TITLE
fix-errors script portability

### DIFF
--- a/fix-errors.sh
+++ b/fix-errors.sh
@@ -10,23 +10,36 @@ FILES=(
   "src/pages/admin/LoanDetails.jsx"
 )
 
+# Suffixe facultatif pour les sauvegardes de sed (par défaut : .bak).
+# Pour ne pas créer de sauvegarde, définir BACKUP_SUFFIX="" avant d'exécuter le script.
+BACKUP_SUFFIX=${BACKUP_SUFFIX-.bak}
+
+# Fonction portable pour sed -i sur macOS et Linux
+sedi() {
+  if [ "$(uname)" = "Darwin" ]; then
+    sed -i "${BACKUP_SUFFIX}" "$@"
+  else
+    sed -i"${BACKUP_SUFFIX}" "$@"
+  fi
+}
+
 # Correction des statusLabels
 for file in "${FILES[@]}"; do
   echo "Correction de $file..."
   # Remplacer les définitions de statusLabels
-  sed -i '' 's/{ text: '"'"'En attente'"'"', bg: '"'"'bg-yellow-100'"'"', text: '"'"'text-yellow-800'"'"' }/{ label: '"'"'En attente'"'"', bg: '"'"'bg-yellow-100'"'"', textColor: '"'"'text-yellow-800'"'"' }/g' "$file"
-  sed -i '' 's/{ text: '"'"'En cours'"'"', bg: '"'"'bg-blue-100'"'"', text: '"'"'text-blue-800'"'"' }/{ label: '"'"'En cours'"'"', bg: '"'"'bg-blue-100'"'"', textColor: '"'"'text-blue-800'"'"' }/g' "$file"
-  sed -i '' 's/{ text: '"'"'Approuvé'"'"', bg: '"'"'bg-green-100'"'"', text: '"'"'text-green-800'"'"' }/{ label: '"'"'Approuvé'"'"', bg: '"'"'bg-green-100'"'"', textColor: '"'"'text-green-800'"'"' }/g' "$file"
-  sed -i '' 's/{ text: '"'"'Rejeté'"'"', bg: '"'"'bg-red-100'"'"', text: '"'"'text-red-800'"'"' }/{ label: '"'"'Rejeté'"'"', bg: '"'"'bg-red-100'"'"', textColor: '"'"'text-red-800'"'"' }/g' "$file"
+  sedi 's/{ text: '"'"'En attente'"'"', bg: '"'"'bg-yellow-100'"'"', text: '"'"'text-yellow-800'"'"' }/{ label: '"'"'En attente'"'"', bg: '"'"'bg-yellow-100'"'"', textColor: '"'"'text-yellow-800'"'"' }/g' "$file"
+  sedi 's/{ text: '"'"'En cours'"'"', bg: '"'"'bg-blue-100'"'"', text: '"'"'text-blue-800'"'"' }/{ label: '"'"'En cours'"'"', bg: '"'"'bg-blue-100'"'"', textColor: '"'"'text-blue-800'"'"' }/g' "$file"
+  sedi 's/{ text: '"'"'Approuvé'"'"', bg: '"'"'bg-green-100'"'"', text: '"'"'text-green-800'"'"' }/{ label: '"'"'Approuvé'"'"', bg: '"'"'bg-green-100'"'"', textColor: '"'"'text-green-800'"'"' }/g' "$file"
+  sedi 's/{ text: '"'"'Rejeté'"'"', bg: '"'"'bg-red-100'"'"', text: '"'"'text-red-800'"'"' }/{ label: '"'"'Rejeté'"'"', bg: '"'"'bg-red-100'"'"', textColor: '"'"'text-red-800'"'"' }/g' "$file"
 
   # Remplacer les usages de text par label
-  sed -i '' 's/statusLabels\[loan.status\].text}/statusLabels[loan.status].label}/g' "$file"
-  sed -i '' 's/${statusLabels\[loan.status\].text}/${statusLabels[loan.status].label}/g' "$file"
-  sed -i '' 's/{statusLabels\[loan.status\].text}/{statusLabels[loan.status].label}/g' "$file"
+  sedi 's/statusLabels\[loan.status\].text}/statusLabels[loan.status].label}/g' "$file"
+  sedi 's/${statusLabels\[loan.status\].text}/${statusLabels[loan.status].label}/g' "$file"
+  sedi 's/{statusLabels\[loan.status\].text}/{statusLabels[loan.status].label}/g' "$file"
   
   # Remplacer les références à text dans les classes par textColor
-  sed -i '' 's/${statusLabels\[loan.status\].bg} ${statusLabels\[loan.status\].text}/${statusLabels[loan.status].bg} ${statusLabels[loan.status].textColor}/g' "$file"
-  sed -i '' 's/{statusLabels\[loan.status\].bg} {statusLabels\[loan.status\].text}/{statusLabels[loan.status].bg} {statusLabels[loan.status].textColor}/g' "$file"
+  sedi 's/${statusLabels\[loan.status\].bg} ${statusLabels\[loan.status\].text}/${statusLabels[loan.status].bg} ${statusLabels[loan.status].textColor}/g' "$file"
+  sedi 's/{statusLabels\[loan.status\].bg} {statusLabels\[loan.status\].text}/{statusLabels[loan.status].bg} {statusLabels[loan.status].textColor}/g' "$file"
 done
 
 echo "Correction terminée!"


### PR DESCRIPTION
## Summary
- make `fix-errors.sh` portable across macOS and Linux
- allow optional in-place backup suffix via `BACKUP_SUFFIX`

## Testing
- `bash fix-errors.sh | head -n 3`
- `BACKUP_SUFFIX= bash fix-errors.sh >/tmp/fix.log && tail -n 2 /tmp/fix.log`

------
https://chatgpt.com/codex/tasks/task_e_683aef8696408322bb4f321514e04db7