### PR TITLE
Add ping API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ cp .env.local.example .env.local
 - Les couleurs dorées ont été ajustées (`#FFD700`) pour un meilleur contraste sur fond sombre.
 - Construire les grilles avec les classes réactives de Tailwind (`sm:`, `md:`, `lg:`) afin d'assurer une mise en page 100% responsive.
 
-## Preview deployments
+## API
 
-To enable preview branches on Vercel to communicate with Supabase, add the following variables in **Preview** with the same values used in **Production**:
+- `GET /api/ping` renvoie `{ "message": "pong" }` pour tester la connectivité du backend.
+
+## Preview deployments
 
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`

--- a/api/ping.js
+++ b/api/ping.js
@@ -1,0 +1,4 @@
+/* eslint-env node */
+export default async function handler(req, res) {
+  res.status(200).json({ message: 'pong' });
+}


### PR DESCRIPTION
## Summary
- add `/api/ping` endpoint to verify backend availability
- document the new endpoint in README

## Testing
- `node - <<'EOF'
import handler from './api/ping.js';
const req = {};
const res = { status(c){ this.code=c; return this; }, json(o){ this.body=o; console.log('status', this.code, 'body', o); }};
await handler(req,res);
EOF`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aef870e988322923a6918c5688b66