### PR TITLE
Fix env vars and lints

### DIFF
--- a/api/register.js
+++ b/api/register.js
@@ -1,11 +1,12 @@
 /* eslint-env node */
+/* global process */
 import { createClient } from '@supabase/supabase-js'
 
 // Initialise le client seulement si toutes les variables sont disponibles
 let supabaseAdmin = null
-if (process.env.VITE_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+if (process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
   supabaseAdmin = createClient(
-    process.env.VITE_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
     process.env.SUPABASE_SERVICE_ROLE_KEY
   )
 }

--- a/src/config/supabaseClient.js
+++ b/src/config/supabaseClient.js
@@ -1,12 +1,16 @@
+/* global process */
 import { createClient } from '@supabase/supabase-js';
 
 // Utilisation des variables NEXT_PUBLIC côté client uniquement
 let supabase = null;
 
 if (typeof window !== 'undefined') {
-  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-  supabase = createClient(supabaseUrl, supabaseAnonKey);
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (supabaseUrl && supabaseAnonKey) {
+    supabase = createClient(supabaseUrl, supabaseAnonKey);
+  }
 }
 
 export { supabase };

--- a/src/hooks/useDocuments.js
+++ b/src/hooks/useDocuments.js
@@ -33,7 +33,7 @@ export const useDocuments = () => {
       }
 
       // Uploader le fichier avec suivi de progression
-      const { data: uploadData, error: uploadError } = await supabase.storage
+      const { error: uploadError } = await supabase.storage
         .from('uploads')
         .upload(filePath, file, {
           cacheControl: '3600',

--- a/src/pages/client/Dashboard.jsx
+++ b/src/pages/client/Dashboard.jsx
@@ -186,7 +186,7 @@ const Dashboard = () => {
             </table>
           ) : (
             <EmptyState
-              message="Vous n'avez encore aucune demande de prêt."
+              message="Vous n&apos;avez encore aucune demande de prêt."
               action={
                 <Link to="/client/demande-pret" className="mt-2 inline-flex text-primary hover:text-primary-dark">
                   Faire votre première demande
@@ -219,7 +219,7 @@ const Dashboard = () => {
                     Type
                   </th>
                   <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                    Date d'ajout
+                    Date d&apos;ajout
                   </th>
                   <th scope="col" className="relative py-3.5 pl-3 pr-4 sm:pr-6">
                     <span className="sr-only">Télécharger</span>
@@ -254,7 +254,7 @@ const Dashboard = () => {
             </table>
           ) : (
             <EmptyState
-              message="Vous n'avez encore aucun document."
+              message="Vous n&apos;avez encore aucun document."
               action={
                 <Link to="/client/documents" className="mt-2 inline-flex text-primary hover:text-primary-dark">
                   Ajouter vos documents

--- a/src/pages/client/Documents.jsx
+++ b/src/pages/client/Documents.jsx
@@ -253,7 +253,7 @@ const Documents = () => {
                     Type
                   </th>
                   <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                    Date d'ajout
+                    Date d&apos;ajout
                   </th>
                   <th scope="col" className="relative py-3.5 pl-3 pr-4 sm:pr-6">
                     <span className="sr-only">Actions</span>
@@ -296,7 +296,7 @@ const Documents = () => {
               </tbody>
             </table>
           ) : (
-            <EmptyState message="Vous n'avez encore aucun document." />
+            <EmptyState message="Vous n&apos;avez encore aucun document." />
           )}
         </div>
       </div>

--- a/src/pages/client/LoanDetails.jsx
+++ b/src/pages/client/LoanDetails.jsx
@@ -266,7 +266,7 @@ const LoanDetails = () => {
                     Type
                   </th>
                   <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                    Date d'ajout
+                    Date d&apos;ajout
                   </th>
                   <th scope="col" className="relative py-3.5 pl-3 pr-4 sm:pr-6">
                     <span className="sr-only">Voir</span>

--- a/src/services/loanService.js
+++ b/src/services/loanService.js
@@ -34,7 +34,7 @@ export const getUserLoanRequests = async (userId) => {
   }
 };
 
-export const getLoanRequestById = async (id, isAdmin = false) => {
+export const getLoanRequestById = async (id) => {
   try {
     const { data, error } = await supabase
       .from('loan_requests')


### PR DESCRIPTION
## Summary
- use NEXT_PUBLIC env names for Supabase client
- escape French apostrophes in dashboard and documents pages
- fix date column titles
- adjust unused vars and ESLint globals

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683c4976cd2483229d404e473fe9d53f