### PR TITLE
Fix Supabase client and escape apostrophes

### DIFF
--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,7 +1,6 @@
 import { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import Button from './Button';
 
 const Modal = ({ 
   isOpen, 

--- a/src/config/supabaseClient.js
+++ b/src/config/supabaseClient.js
@@ -1,17 +1,23 @@
 /* global process */
 import { createClient } from '@supabase/supabase-js';
 
-// Utilisation des variables NEXT_PUBLIC côté client uniquement
-let supabase = null;
+// Récupération des variables d'environnement en tenant compte
+// d'une éventuelle absence de l'objet process côté navigateur
+let supabaseUrl;
+let supabaseAnonKey;
 
-if (typeof window !== 'undefined') {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (supabaseUrl && supabaseAnonKey) {
-    supabase = createClient(supabaseUrl, supabaseAnonKey);
-  }
+if (typeof process !== 'undefined') {
+  supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+} else if (typeof import.meta !== 'undefined') {
+  supabaseUrl = import.meta.env.NEXT_PUBLIC_SUPABASE_URL;
+  supabaseAnonKey = import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 }
+
+const supabase =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey)
+    : null;
 
 export { supabase };
 export default supabase;

--- a/src/pages/admin/LoanDetails.jsx
+++ b/src/pages/admin/LoanDetails.jsx
@@ -485,12 +485,12 @@ const LoanDetails = () => {
                   }}
                   fullWidth
                 >
-                  Modifier l'assignation
+                  Modifier l&apos;assignation
                 </Button>
               </div>
             ) : (
               <div>
-                <p className="text-center text-gray-500 mb-4">Cette demande n'est pas encore assignée</p>
+                <p className="text-center text-gray-500 mb-4">Cette demande n&apos;est pas encore assignée</p>
                 <Button 
                   variant="primary" 
                   size="sm"
@@ -617,7 +617,7 @@ const LoanDetails = () => {
             onChange={() => setAssignedTo(assignedTo ? '' : loan.assigned_to || '')}
           />
           <label htmlFor="remove-assignation" className="ml-2 block text-sm text-gray-900">
-            Retirer l'assignation actuelle
+            Retirer l&apos;assignation actuelle
           </label>
         </div>
       </Modal>


### PR DESCRIPTION
## Summary
- remove unused import in `Modal`
- handle runtime env vars in `supabaseClient`
- escape apostrophes in loan details labels

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683c4f195e30832297fcaadc0565d99d