### PR TITLE
Add unescaped entities rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,7 +21,8 @@ module.exports = {
   rules: {
     'no-unused-vars': 'warn',
     'react/react-in-jsx-scope': 'off',
-    'react/prop-types': 'off'
+    'react/prop-types': 'off',
+    'react/no-unescaped-entities': 'error'
   },
   settings: {
     react: {


### PR DESCRIPTION
## Summary
- enforce `react/no-unescaped-entities` to avoid HTML apostrophe issues

## Testing
- `npx eslint .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683c99f3620083228a30eb0105ae9c0c