### PR TITLE
Fix Vercel errors

### DIFF
--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -22,7 +22,7 @@ const Footer = () => {
               <span className="ml-2 text-lg font-bold text-primary group-hover:underline">Africa Invest Capital</span>
             </a>
             <p className="mt-2 text-noir opacity-90">
-              Solutions financières innovantes pour l’Afrique
+              Solutions financières innovantes pour l&apos;Afrique
             </p>
           </div>
           
@@ -68,7 +68,7 @@ const Footer = () => {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
-                <span className="font-bold">123 Rue Principale, Abidjan, Côte d’Ivoire</span>
+                  <span className="font-bold">123 Rue Principale, Abidjan, Côte d&apos;Ivoire</span>
               </li>
               <li className="text-noir flex items-center font-bold hover:text-or transition-colors duration-200">
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/config/supabaseClient.js
+++ b/src/config/supabaseClient.js
@@ -1,11 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_URL : undefined;
-const supabaseAnonKey = typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY : undefined;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(
-    'Supabase credentials are missing. Check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your environment variables.'
+    'Supabase credentials are missing. Check VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment variables.'
   );
 }
 


### PR DESCRIPTION
## Summary
- escape apostrophes in footer text
- use `import.meta.env` for Supabase config

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint.flat.config.js')*

------
https://chatgpt.com/codex/tasks/task_e_683cccd87f908322a90247cd11d45612