### PR TITLE
Fix ESLint issues

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
-import Bars3Icon from '@heroicons/react/24/outline/Bars3Icon';
-import UserCircleIcon from '@heroicons/react/24/outline/UserCircleIcon';
-import XMarkIcon from '@heroicons/react/24/outline/XMarkIcon';
+import {
+  Bars3Icon,
+  UserCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 
 const Header = ({ isAdmin, toggleSidebar, user }) => {
   const { logout } = useAuth();

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,11 +1,13 @@
 import { Link, useLocation } from 'react-router-dom';
-import XMarkIcon from '@heroicons/react/24/outline/XMarkIcon';
-import HomeIcon from '@heroicons/react/24/outline/HomeIcon';
-import DocumentTextIcon from '@heroicons/react/24/outline/DocumentTextIcon';
-import UserIcon from '@heroicons/react/24/outline/UserIcon';
-import UsersIcon from '@heroicons/react/24/outline/UsersIcon';
-import CurrencyDollarIcon from '@heroicons/react/24/outline/CurrencyDollarIcon';
-import Cog6ToothIcon from '@heroicons/react/24/outline/Cog6ToothIcon';
+import {
+  XMarkIcon,
+  HomeIcon,
+  DocumentTextIcon,
+  UserIcon,
+  UsersIcon,
+  CurrencyDollarIcon,
+  Cog6ToothIcon,
+} from '@heroicons/react/24/outline';
 
 const Sidebar = ({ isAdmin, isOpen, toggleSidebar }) => {
   const location = useLocation();

--- a/src/config/supabaseClient.js
+++ b/src/config/supabaseClient.js
@@ -1,11 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Next.js exposes public env vars with the NEXT_PUBLIC_ prefix
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(
-    'Supabase credentials are missing. Check VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment variables.'
+    'Supabase credentials are missing. Check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your environment variables.'
   );
 }
 

--- a/src/pages/admin/ClientDetails.jsx
+++ b/src/pages/admin/ClientDetails.jsx
@@ -210,7 +210,7 @@ const ClientDetails = () => {
                           {doc.file_name}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {doc.category === 'identite' && 'Pièce d’identité'}
+                          {doc.category === 'identite' && "Pièce d'identité"}
                           {doc.category === 'revenu' && 'Justificatif de revenu'}
                           {doc.category === 'banque' && 'Relevés bancaires'}
                           {doc.category === 'domicile' && 'Justificatif de domicile'}
@@ -271,7 +271,7 @@ const ClientDetails = () => {
               </div>
               
               <div>
-                <p className="text-sm font-medium text-gray-500">Date d’inscription</p>
+                  <p className="text-sm font-medium text-gray-500">Date d&apos;inscription</p>
                 <p className="mt-1">{formatDate(client.created_at)}</p>
               </div>
             </div>

--- a/src/pages/admin/Dashboard.jsx
+++ b/src/pages/admin/Dashboard.jsx
@@ -4,12 +4,14 @@ import { supabase } from '../../config/supabaseClient';
 import { useAuth } from '../../hooks/useAuth';
 
 // Importation directe des icônes
-import UsersIcon from '@heroicons/react/24/outline/UsersIcon';
-import CurrencyDollarIcon from '@heroicons/react/24/outline/CurrencyDollarIcon';
-import DocumentTextIcon from '@heroicons/react/24/outline/DocumentTextIcon';
-import ClockIcon from '@heroicons/react/24/outline/ClockIcon';
-import CheckCircleIcon from '@heroicons/react/24/outline/CheckCircleIcon';
-import ExclamationCircleIcon from '@heroicons/react/24/outline/ExclamationCircleIcon';
+import {
+  UsersIcon,
+  CurrencyDollarIcon,
+  DocumentTextIcon,
+  ClockIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
 
 const statusColors = {
   pending: 'bg-yellow-100 text-yellow-800',

--- a/src/pages/admin/Loans.jsx
+++ b/src/pages/admin/Loans.jsx
@@ -7,9 +7,11 @@ import Loader from '../../components/common/Loader';
 import EmptyState from '../../components/common/EmptyState';
 
 // Importation directe des icônes
-import FunnelIcon from '@heroicons/react/24/outline/FunnelIcon';
-import ChevronDownIcon from '@heroicons/react/24/outline/ChevronDownIcon';
-import ExclamationCircleIcon from '@heroicons/react/24/outline/ExclamationCircleIcon';
+import {
+  FunnelIcon,
+  ChevronDownIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
 import { loanStatusMap, loanTypeLabels } from '../../utils/constants';
 
 const statusColors = Object.fromEntries(

--- a/src/pages/client/Dashboard.jsx
+++ b/src/pages/client/Dashboard.jsx
@@ -6,11 +6,13 @@ import Loader from '../../components/common/Loader';
 import EmptyState from '../../components/common/EmptyState';
 
 // Importation directe des icônes
-import DocumentTextIcon from '@heroicons/react/24/outline/DocumentTextIcon';
-import CurrencyDollarIcon from '@heroicons/react/24/outline/CurrencyDollarIcon';
-import ClockIcon from '@heroicons/react/24/outline/ClockIcon';
-import CheckCircleIcon from '@heroicons/react/24/outline/CheckCircleIcon';
-import ExclamationCircleIcon from '@heroicons/react/24/outline/ExclamationCircleIcon';
+import {
+  DocumentTextIcon,
+  CurrencyDollarIcon,
+  ClockIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
 
 const statusColors = {
   pending: 'bg-yellow-100 text-yellow-800',

--- a/src/pages/client/LoanDetails.jsx
+++ b/src/pages/client/LoanDetails.jsx
@@ -5,9 +5,11 @@ import { useAuth } from '../../hooks/useAuth';
 
 // Importation directe des icônes
 import { loanStatusMap, loanTypeLabels } from '../../utils/constants';
-import ClockIcon from '@heroicons/react/24/outline/ClockIcon';
-import CheckCircleIcon from '@heroicons/react/24/outline/CheckCircleIcon';
-import ExclamationCircleIcon from '@heroicons/react/24/outline/ExclamationCircleIcon';
+import {
+  ClockIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
 import StatusBadge from '../../components/common/StatusBadge';
 
 const statusIcons = Object.fromEntries(

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,8 @@
-import ClockIcon from '@heroicons/react/24/outline/ClockIcon';
-import CheckCircleIcon from '@heroicons/react/24/outline/CheckCircleIcon';
-import ExclamationCircleIcon from '@heroicons/react/24/outline/ExclamationCircleIcon';
+import {
+  ClockIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
 
 export const loanStatusMap = {
   pending: {


### PR DESCRIPTION
## Summary
- use `process.env` for Supabase config
- use named Heroicons imports for Next.js
- escape French apostrophes in admin client details

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot read config file)*

------
https://chatgpt.com/codex/tasks/task_e_683ccf510ecc83228320dfa70202783a