### PR TITLE
Fix apostrophe escaping

### DIFF
--- a/src/pages/admin/ClientDetails.jsx
+++ b/src/pages/admin/ClientDetails.jsx
@@ -210,7 +210,7 @@ const ClientDetails = () => {
                           {doc.file_name}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {doc.category === 'identite' && "Pièce d'identité"}
+                          {doc.category === 'identite' && "Pièce d&apos;identité"}
                           {doc.category === 'revenu' && 'Justificatif de revenu'}
                           {doc.category === 'banque' && 'Relevés bancaires'}
                           {doc.category === 'domicile' && 'Justificatif de domicile'}


### PR DESCRIPTION
## Summary
- escape apostrophe in admin client details page to satisfy eslint rule

## Testing
- `npm run lint` *(fails: Cannot read config file)*

------
https://chatgpt.com/codex/tasks/task_e_683cd281d8808322aae4ba461f4e0e8a