### PR TITLE
Fix Supabase env loading

### DIFF
--- a/src/config/supabaseClient.js
+++ b/src/config/supabaseClient.js
@@ -1,9 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+// Vite n'expose que les variables préfixées par `envPrefix`. On utilise
+// `NEXT_PUBLIC_` pour rester cohérent avec l'ancienne configuration, d'où
+// l'ajout de ce préfixe dans `vite.config.js`.
+const supabaseUrl = import.meta.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseAnonKey = import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 
-if (typeof window !== 'undefined' && (!supabaseUrl || !supabaseAnonKey)) {
+if (!supabaseUrl || !supabaseAnonKey) {
   console.error(
     'Supabase credentials are missing. Check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your environment variables.'
   );

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
+  envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- use `import.meta.env` to read Supabase credentials
- expose `NEXT_PUBLIC_` env variables in Vite config

## Testing
- `npm run lint` *(fails: Cannot read config file)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68619212f56883228c27fdf54df72077